### PR TITLE
Add placeholders for ARwrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgloader",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Loader for CGTrader ARsenal services",
   "main": "umd/index.js",
   "scripts": {

--- a/src/components/arwrapper.js
+++ b/src/components/arwrapper.js
@@ -1,4 +1,20 @@
 import link from './link'
+import {
+  IS_IOS,
+  IS_AR_QUICKLOOK_CANDIDATE,
+  IS_ANDROID,
+} from './utils'
+
+const placeholderAR = 'https://viewer.cgtarsenal.com/js/images/view-in-ar.png'
+const placeholder3D = 'https://viewer.cgtarsenal.com/js/images/view-in-3d.png'
+
+function placeholderSrc() {
+  if ((IS_IOS && IS_AR_QUICKLOOK_CANDIDATE()) || IS_ANDROID) {
+    return placeholderAR
+  }
+
+  return placeholder3D
+}
 
 export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   // Get formatted link
@@ -10,8 +26,21 @@ export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   // Replace target with wrapped target
   target.remove()
 
-  // Wrap target component
-  tempLink.appendChild(target)
+  // Check if target is not empty
+  if (target.nodeName !== "IMG" && target.innerHTML === '') {
+    const placeholder = document.createElement('img')
+
+    placeholder.setAttribute('src', placeholderSrc())
+    placeholder.setAttribute('alt', 'View in 3D')
+
+    // Wrap target component
+    tempLink.appendChild(placeholder)
+  } else {
+    // Wrap target component
+    tempLink.appendChild(target)
+  }
+
+  tempLink.setAttribute('alt', 'View in 3D')
 
   return parent.appendChild(tempLink)
 }

--- a/src/components/qrgenerator.js
+++ b/src/components/qrgenerator.js
@@ -1,17 +1,21 @@
 import link from './link'
 
 export default function QRGenerator(viewerUrl, gltfUrl, usdzUrl, landingUrl, target) {
-  const QRCode = require('qrcode-svg');
+  const QRCode = require('qrcode-svg')
   const qrcode = new QRCode({
     content: landingUrl,
     join: true,
-    container: "svg-viewbox" //Useful but not required
+    container: "svg-viewbox",
+    xmlDeclaration: false
   }).svg()
 
   // Get formatted link
   const tempLink = link(viewerUrl, gltfUrl, usdzUrl)
 
-  tempLink.innerHTML = qrcode
+  const img = new Image()
+  img.src = 'data:image/svg+xml;base64,' + window.btoa(qrcode)
+
+  tempLink.appendChild(img)
 
   return target.appendChild(tempLink)
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,5 +1,5 @@
 import Embed from './components/embed'
-import URL from './components/utils'
+import { URL } from './components/utils'
 import ARWrapper from './components/arwrapper'
 import QRGenerator from './components/qrgenerator'
 


### PR DESCRIPTION
Added placeholder images when AR wrapper is not and image and it's empty. Look like so:

![Screenshot 2020-04-14 at 15 55 35](https://user-images.githubusercontent.com/25665593/79227395-80279e00-7e68-11ea-907f-31a41629f498.png)

Also QR code svg is added as src for image. This way it jumps straight to QR on iOS and removed extra click that was there before