### PR TITLE
Feature/fix redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cgloader",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgloader",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Loader for CGTrader ARsenal services",
   "main": "umd/index.js",
   "scripts": {

--- a/src/components/gallerybutton.js
+++ b/src/components/gallerybutton.js
@@ -6,7 +6,7 @@ import {
 } from './utils'
 import Button from './button'
 import ARModal from './armodal'
-import yeet from './yeet'
+import redirect from './redirect'
 
 const styles = `
   #arsenal-button {
@@ -101,27 +101,7 @@ const styles = `
 
 export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid, token) {
   function onClick() {
-    const tempLink = link(landingPath, gltfUrl, usdzUrl)
-
-    if (IS_IOS && IS_AR_QUICKLOOK_CANDIDATE()) {
-      const image = new Image()
-
-      tempLink.appendChild(image)
-
-      yeet(uid, 'arkit', 'click_gallery_button', token)
-
-      return tempLink.click()
-    }
-
-    if (IS_ANDROID) {
-      yeet(uid, 'arcore', 'click_gallery_button', token)
-
-      return tempLink.click()
-    }
-
-    yeet(uid, 'desktop', 'click_gallery_button', token)
-
-    return openModal()
+    redirect(uid, token, landingPath, gltfUrl, usdzUrl, 'click_gallery_button', openModal)
   }
 
   const modal = ARModal(landingPath, closeModal)

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -11,16 +11,16 @@ export default function link(viewerUrl, gltfUrl, usdzUrl) {
     tempLink.setAttribute('href', usdzUrl)
     tempLink.setAttribute('rel', 'ar')
   } else if (IS_ANDROID) {
-    const viewerURL = new URL('intent://arvr.google.com/scene-viewer/1.0')
-    viewerURL.search = `file=${gltfUrl}&mode=ar_preferred`
+    const androidViewer = new URL('intent://arvr.google.com/scene-viewer/1.0')
+    androidViewer.search = `file=${gltfUrl}&mode=ar_preferred`
 
     const url = [
-      viewerURL.toString(),
+      androidViewer.toString(),
       '#Intent;',
       `scheme=https;`,
       'package=com.google.ar.core;',
       'action=android.intent.action.VIEW;',
-      `S.browser_fallback_url=${encodeURIComponent(viewerUrl.toString())};`,
+      `S.browser_fallback_url=${encodeURIComponent(androidViewer.toString())};`,
       'end;',
     ].join('')
 

--- a/src/components/redirect.js
+++ b/src/components/redirect.js
@@ -1,0 +1,31 @@
+import {
+  IS_IOS,
+  IS_AR_QUICKLOOK_CANDIDATE,
+  IS_ANDROID,
+} from './utils'
+import link from './link'
+import yeet from './yeet'
+
+export default function redirect(uid, token, landingPath, gltfUrl, usdzUrl, trackAction, callback) {
+  const tempLink = link(landingPath, gltfUrl, usdzUrl)
+
+  if (IS_IOS && IS_AR_QUICKLOOK_CANDIDATE()) {
+      const image = new Image()
+
+      tempLink.appendChild(image)
+
+      yeet(uid, 'arkit', trackAction, token)
+
+      return tempLink.click()
+  }
+
+  if (IS_ANDROID) {
+      yeet(uid, 'arcore', trackAction, token)
+
+      return tempLink.click()
+  }
+
+  yeet(uid, 'desktop', trackAction, token)
+
+  return callback()
+}

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -5,8 +5,9 @@ const UA = typeof nav !== 'undefined' ? nav.userAgent : ''
 const platform = typeof nav !== 'undefined' ? nav.platform : ''
 const maxTouchPoints = typeof nav !== 'undefined' ? nav.maxTouchPoints : ''
 
-// Viewer repo
+// Constants
 export const URL = 'https://viewer.cgtarsenal.com/'
+export const ARParam = 'cgtar'
 
 // iOS checks
 export const IS_IOS = (/iPad|iPhone|iPod/.test(UA) && !win.MSStream) ||
@@ -20,3 +21,29 @@ export function IS_AR_QUICKLOOK_CANDIDATE() {
 
 // Android checks
 export const IS_ANDROID = /android/i.test(UA)
+
+// Build URL
+export function urlBuilder(item, user, uid) {
+  return !!item ? `${URL}${user}/${uid}/${item}` : undefined
+}
+
+// Viewer params
+export  function getViewerParams(query, arsenal, multipleViewers) {
+  const params = query.substr(1).split('&')
+  let ID = null
+  
+  for (let i = 0; i < params.length; i++) {
+    const newParam = params[i].split('=')
+    
+    if (newParam[0] === ARParam) {
+      ID = newParam[1]
+    }
+  }
+
+  if (!ID) return false
+
+  if (multipleViewers) {
+    const currentViewer = arsenal.filter((viewer) => viewer.uid === ID)
+    return currentViewer[0]
+  }
+}

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -7,7 +7,7 @@ const maxTouchPoints = typeof nav !== 'undefined' ? nav.maxTouchPoints : ''
 
 // Constants
 export const URL = 'https://viewer.cgtarsenal.com/'
-export const ARParam = 'cgtar'
+export const ARParam = 'cgtAR'
 
 // iOS checks
 export const IS_IOS = (/iPad|iPhone|iPod/.test(UA) && !win.MSStream) ||


### PR DESCRIPTION
This will change how QR code is generated and how redirection from QR scanned link to AR works:
- Loader will grab link of the page it's sitting in via `window.location` and Instead of `viewer.cgtrader.com/..../landing` it will use `window.location.href`
- Extra search param `cgtAR={viewer_id}` is added to new landing URL 
- Loader will check for `cgtAR` param in URl and if it's found will redirect to AR on mobile devices and do nothing on desktop

With these updates we'll improve UX as scanned QR code lands user to clients website and after AR view is closed user stays in clients page instead of empty landing as it's now

<hr>

https://app.clubhouse.io/cgtrader/story/37317/update-qr-and-ar-button-redirects