### PR TITLE
Reduce errors & not require all targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgloader",
-  "version": "1.1.38",
+  "version": "1.1.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cgloader",
-      "version": "1.1.38",
+      "version": "1.1.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgloader",
-  "version": "1.1.38",
+  "version": "1.1.40",
   "description": "Loader for CGTrader ARsenal services",
   "main": "umd/index.js",
   "scripts": {

--- a/src/components/armodal.js
+++ b/src/components/armodal.js
@@ -38,7 +38,7 @@ export default function ARModal(landingUrl, close) {
   closeModalBtn.addEventListener('click', (event) => close(event, true))
 
   // Add close button to modal
-  modal.children[0].appendChild(closeModalBtn)
+  modal.children[0]?.appendChild(closeModalBtn)
 
   return modal
 }

--- a/src/components/arwrapper.js
+++ b/src/components/arwrapper.js
@@ -17,6 +17,10 @@ function placeholderSrc() {
 }
 
 export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
+  if (!target) {
+    return
+  }
+
   // Get formatted link
   const tempLink = link(viewerUrl, gltfUrl, usdzUrl, true)
 
@@ -24,20 +28,20 @@ export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   const parent = target?.parentNode
 
   // Replace target with wrapped target
-  target.remove()
+  target?.remove()
 
   // Check if target is not empty
-  if (target.nodeName !== "IMG" && target.innerHTML === '') {
+  if (target && target.nodeName !== "IMG" && target.innerHTML === '') {
     const placeholder = document.createElement('img')
 
     placeholder.setAttribute('src', placeholderSrc())
     placeholder.setAttribute('alt', 'View in 3D')
 
     // Wrap target component
-    tempLink.appendChild(placeholder)
+    tempLink?.appendChild(placeholder)
   } else {
     // Wrap target component
-    tempLink.appendChild(target)
+    tempLink?.appendChild(target)
   }
 
   tempLink.setAttribute('alt', 'View in 3D')

--- a/src/components/arwrapper.js
+++ b/src/components/arwrapper.js
@@ -25,26 +25,26 @@ export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   const tempLink = link(viewerUrl, gltfUrl, usdzUrl, true)
 
   // Find target parent
-  const parent = target?.parentNode
+  const parent = target.parentNode
 
   // Replace target with wrapped target
-  target?.remove()
+  target.remove()
 
   // Check if target is not empty
-  if (target && target.nodeName !== "IMG" && target.innerHTML === '') {
+  if (target.nodeName !== "IMG" && target.innerHTML === '') {
     const placeholder = document.createElement('img')
 
     placeholder.setAttribute('src', placeholderSrc())
     placeholder.setAttribute('alt', 'View in 3D')
 
     // Wrap target component
-    tempLink?.appendChild(placeholder)
+    tempLink.appendChild(placeholder)
   } else {
     // Wrap target component
-    tempLink?.appendChild(target)
+    tempLink.appendChild(target)
   }
 
   tempLink.setAttribute('alt', 'View in 3D')
 
-  return parent?.appendChild(tempLink)
+  return parent.appendChild(tempLink)
 }

--- a/src/components/gallerybutton.js
+++ b/src/components/gallerybutton.js
@@ -109,7 +109,7 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
 
   function openModal() {
     document.body.style.overflow = 'hidden'
-    document.body.appendChild(modal)
+    document.body?.appendChild(modal)
     setTimeout(() => modal.classList.add('is-shown'), 10)
   }
 
@@ -117,8 +117,8 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
     if (!(e.target === modal || bypass)) return
 
     document.body.style.overflow = null
-    modal.classList.remove('is-shown')
-    setTimeout(() => modal.remove(), 410)
+    modal?.classList?.remove('is-shown')
+    setTimeout(() => modal?.remove(), 410)
   }
 
   modal.addEventListener('click', (event) => closeModal(event))
@@ -130,5 +130,5 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
 
   const placeholder = Button(onClick)
 
-  return target.appendChild(placeholder)
+  return target?.appendChild(placeholder)
 }

--- a/src/components/gallerybutton.js
+++ b/src/components/gallerybutton.js
@@ -101,6 +101,10 @@ const styles = `
 `
 
 export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid, token) {
+  if (!target) {
+    return
+  }
+
   function onClick() {
     redirect(uid, token, landingPath, gltfUrl, usdzUrl, 'click_gallery_button', openModal)
   }

--- a/src/components/gallerybutton.js
+++ b/src/components/gallerybutton.js
@@ -113,7 +113,7 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
 
   function openModal() {
     document.body.style.overflow = 'hidden'
-    document.body?.appendChild(modal)
+    document.body.appendChild(modal)
     setTimeout(() => modal.classList.add('is-shown'), 10)
   }
 
@@ -121,8 +121,8 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
     if (!(e.target === modal || bypass)) return
 
     document.body.style.overflow = null
-    modal?.classList?.remove('is-shown')
-    setTimeout(() => modal?.remove(), 410)
+    modal.classList.remove('is-shown')
+    setTimeout(() => modal.remove(), 410)
   }
 
   modal.addEventListener('click', (event) => closeModal(event))
@@ -134,5 +134,5 @@ export default function GalleryButton(landingPath, gltfUrl, usdzUrl, target, uid
 
   const placeholder = Button(onClick)
 
-  return target?.appendChild(placeholder)
+  return target.appendChild(placeholder)
 }

--- a/src/components/metadata.js
+++ b/src/components/metadata.js
@@ -1,4 +1,8 @@
 function Metadata(image, gltf, usdz, name, target) {
+  if (!target) {
+    return
+  }
+
   const script = document.createElement('script')
 
   function returnValue(title, value) {
@@ -23,7 +27,7 @@ function Metadata(image, gltf, usdz, name, target) {
   script.type = "application/ld+json"
   script.text = data.replace(/^\s*[\r\n]/gm, '') // Remove empty lines caused by missing params
 
-  target?.appendChild(script)
+  target.appendChild(script)
 }
 
 export default Metadata

--- a/src/components/metadata.js
+++ b/src/components/metadata.js
@@ -23,7 +23,7 @@ function Metadata(image, gltf, usdz, name, target) {
   script.type = "application/ld+json"
   script.text = data.replace(/^\s*[\r\n]/gm, '') // Remove empty lines caused by missing params
 
-  target.appendChild(script)
+  target?.appendChild(script)
 }
 
 export default Metadata

--- a/src/components/qrgenerator.js
+++ b/src/components/qrgenerator.js
@@ -1,6 +1,10 @@
 import link from './link'
 
 export default function QRGenerator(viewerUrl, gltfUrl, usdzUrl, landingUrl, target) {
+  if (!target) {
+    return
+  }
+
   const QRCode = require('qrcode-svg')
   const qrcode = new QRCode({
     content: landingUrl,
@@ -15,7 +19,7 @@ export default function QRGenerator(viewerUrl, gltfUrl, usdzUrl, landingUrl, tar
   const img = new Image()
   img.src = 'data:image/svg+xml;base64,' + window.btoa(qrcode)
 
-  tempLink?.appendChild(img)
+  tempLink.appendChild(img)
 
-  return target?.appendChild(tempLink)
+  return target.appendChild(tempLink)
 }

--- a/src/components/qrgenerator.js
+++ b/src/components/qrgenerator.js
@@ -15,7 +15,7 @@ export default function QRGenerator(viewerUrl, gltfUrl, usdzUrl, landingUrl, tar
   const img = new Image()
   img.src = 'data:image/svg+xml;base64,' + window.btoa(qrcode)
 
-  tempLink.appendChild(img)
+  tempLink?.appendChild(img)
 
   return target?.appendChild(tempLink)
 }

--- a/src/components/redirect.js
+++ b/src/components/redirect.js
@@ -12,7 +12,7 @@ export default function redirect(uid, token, landingPath, gltfUrl, usdzUrl, trac
   if (IS_IOS && IS_AR_QUICKLOOK_CANDIDATE()) {
       const image = new Image()
 
-      tempLink?.appendChild(image)
+      tempLink.appendChild(image)
 
       yeet(uid, 'arkit', trackAction, token)
 

--- a/src/components/redirect.js
+++ b/src/components/redirect.js
@@ -12,7 +12,7 @@ export default function redirect(uid, token, landingPath, gltfUrl, usdzUrl, trac
   if (IS_IOS && IS_AR_QUICKLOOK_CANDIDATE()) {
       const image = new Image()
 
-      tempLink.appendChild(image)
+      tempLink?.appendChild(image)
 
       yeet(uid, 'arkit', trackAction, token)
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -66,7 +66,7 @@ import redirect from './components/redirect'
       const iframe = new Embed(viewerPath)
 
       // Append iframe to target placeholder
-      domTarget?.appendChild(iframe)
+      domTarget.appendChild(iframe)
     }
 
     if (status.metadataMissing) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -45,6 +45,10 @@ import redirect from './components/redirect'
     } = viewerParams
     const domTarget = document.querySelector(target)
 
+    if (document && (!domTarget || !viewer)) {
+      return console.warn(`Viewer type: ${viewer} for product: ${name} did not find target: ${target}`)
+    }
+
     // Check if required viewer props are defined
     if (!uid && !user && !viewer && !target) {
       return console.error('Required params missing for', uid)
@@ -62,7 +66,7 @@ import redirect from './components/redirect'
       const iframe = new Embed(viewerPath)
 
       // Append iframe to target placeholder
-      domTarget.appendChild(iframe)
+      domTarget?.appendChild(iframe)
     }
 
     if (status.metadataMissing) {


### PR DESCRIPTION
## Returns console warning if domTarget isn't found
<img width="1253" alt="Screenshot 2022-11-16 at 11 09 11" src="https://user-images.githubusercontent.com/28951443/202137783-7066aea8-a186-4ca4-b07f-336e42d0f3aa.png">

## Other viewers in the page doesn't break anymore if one of the viewers is not available
<img width="1920" alt="Screenshot 2022-11-16 at 11 10 12" src="https://user-images.githubusercontent.com/28951443/202138018-b16dc2b4-cdd0-4365-b9ae-cf11094ef3fd.png">

## Reduces some other random console errors, when targets are not found, not available