### PR TITLE
Fix iOS Wrapper embed not working as expected with non img targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgloader",
-  "version": "1.1.45",
+  "version": "1.1.46",
   "description": "Loader for CGTrader ARsenal services",
   "main": "umd/index.js",
   "scripts": {

--- a/src/components/arwrapper.js
+++ b/src/components/arwrapper.js
@@ -21,7 +21,7 @@ export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   }
 
   // Get formatted link
-  const tempLink = link(viewerUrl, gltfUrl, usdzUrl, true)
+  const tempLink = link(viewerUrl, gltfUrl, usdzUrl)
 
   // Find target parent
   const parent = target.parentNode
@@ -41,9 +41,14 @@ export default function ARWrapper(viewerUrl, gltfUrl, usdzUrl, target) {
   } else {
     // Wrap target component
     tempLink.appendChild(target)
-  }
 
-  tempLink.setAttribute('alt', 'View in 3D')
+    // On iOS for a link to work, first element of the link needs to be an <img>
+    if (target.nodeName !== "IMG" && IS_AR_QUICKLOOK_CANDIDATE()) {
+      const hiddenImg = document.createElement('img')
+      hiddenImg.style = 'display: none'
+      tempLink.prepend(hiddenImg)
+    }
+  }
 
   return parent.appendChild(tempLink)
 }

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -3,12 +3,11 @@ import {
   IS_ANDROID,
 } from './utils'
 
-export default function link(viewerUrl, gltfUrl, usdzUrl, isFromARWrapper = false) {
+export default function link(viewerUrl, gltfUrl, usdzUrl) {
   const tempLink = document.createElement('a')
-  const url = isFromARWrapper ? viewerUrl : usdzUrl
 
   if (IS_AR_QUICKLOOK_CANDIDATE()) {
-    tempLink.setAttribute('href', url)
+    tempLink.setAttribute('href', usdzUrl)
     tempLink.setAttribute('rel', 'ar')
   } else if (IS_ANDROID) {
     const androidViewer = new URL('intent://arvr.google.com/scene-viewer/1.0')


### PR DESCRIPTION
Wrapper embed did work as expected if the target was `<img>` but failed if target was `<div>` or anything else. This is because a link with `rel="ar"` on iOS only works if the first child of a link is `<img>`.
This fix generates an empty/hidden `<img>` on iOS in those cases.